### PR TITLE
block-rules: paragraph following thematic break fix

### DIFF
--- a/__tests__/rules/markdown-zero-diff.ts
+++ b/__tests__/rules/markdown-zero-diff.ts
@@ -118,8 +118,9 @@ const examplesOmit = new Set([
     57, 60, 61,
     // headers are not implemented
     59,
-    // paragraphs are not implemented
-    55, 58, 49,
+    // leading spaces are consumed by the parser
+    49,
+
     // code indent blocks are not implemented
     48,
     // spaces consumed by the parser

--- a/src/rules/block/paragraph.ts
+++ b/src/rules/block/paragraph.ts
@@ -21,7 +21,18 @@ const paragraph: Renderer.RenderRuleRecord = {
             throw new Error('failed to rendrer paragraph');
         }
 
-        rendered += this.EOL.repeat(2);
+        if (!previous.block) {
+            return '';
+        }
+
+        // vertical blocks separation
+        if (previous.type === 'hr') {
+            // thematic breaks can interrupt paragraphs
+            // therefore empty line between it and paragraphs isn't required
+            rendered += this.EOL;
+        } else {
+            rendered += this.EOL.repeat(2);
+        }
 
         return rendered;
     },


### PR DESCRIPTION
[4.8 Paragraphs](https://spec.commonmark.org/0.30/#paragraphs) #10

handle case of paragraph following thematic break

thematic breaks can interrupt paragraphs, therefore empty line
between thematic break and paragraph is not mandatory

@3y3 