### PR TITLE
block-rules: indented code blocks

### DIFF
--- a/__tests__/rules/markdown-zero-diff.ts
+++ b/__tests__/rules/markdown-zero-diff.ts
@@ -43,6 +43,7 @@ const sectionsKeep = new Set([
     'Paragraphs',
     'ATX headings',
     'Setext headings',
+    'Indented code blocks',
 ]);
 
 const examplesOmit = new Set([
@@ -161,6 +162,14 @@ const examplesOmit = new Set([
     99, 94,
     // intended to fail
     104,
+
+    // 'Indented code blocks',
+    // trailling spaces consumed by the parser
+    111,
+    // indentation inside paragraph after softbreak is consumed by the parser
+    113,
+    // lists are not implemented
+    108, 109,
 ]);
 
 const units = tests.filter(({section, number}) => {

--- a/src/rules/block/code.ts
+++ b/src/rules/block/code.ts
@@ -1,0 +1,62 @@
+import {Options} from 'markdown-it';
+import Renderer from 'markdown-it/lib/renderer';
+import Token from 'markdown-it/lib/token';
+
+import {MarkdownRenderer, MarkdownRendererEnv} from 'src/renderer';
+
+const code: Renderer.RenderRuleRecord = {
+    code_block: function (
+        this: MarkdownRenderer,
+        tokens: Token[],
+        i: number,
+        options: Options,
+        env: MarkdownRendererEnv,
+    ) {
+        const token = tokens[i];
+
+        let rendered = '';
+
+        // vertical separation
+        if (i) {
+            rendered += this.EOL;
+        }
+
+        let indentation = 0;
+
+        // determine indentation
+        const [start, end] = token.map ?? [];
+        const {source} = env;
+        if (start && end && source) {
+            const [first] = source.slice(start, end);
+
+            const [spaces] = first.match(/(^\s+)/mu) ?? [''];
+
+            indentation += spaces.length;
+        } else {
+            indentation += 4;
+        }
+
+        const contentLines = token.content.split('\n');
+
+        let content = '';
+
+        for (const line of contentLines) {
+            if (line.length) {
+                content += this.SPACE.repeat(indentation);
+            }
+
+            content += line;
+
+            content += this.EOL;
+        }
+
+        content = content.replace(/(\s*$)/gu, '');
+
+        rendered += content;
+
+        return rendered;
+    },
+};
+
+export {code};
+export default {code};

--- a/src/rules/block/index.ts
+++ b/src/rules/block/index.ts
@@ -3,11 +3,13 @@ import Renderer from 'markdown-it/lib/renderer';
 import {hr} from './hr';
 import {paragraph} from './paragraph';
 import {heading} from './heading';
+import {code} from './code';
 
 const block: Renderer.RenderRuleRecord = {
     ...paragraph,
     ...heading,
     ...hr,
+    ...code,
 };
 
 export {block};

--- a/src/rules/block/paragraph.ts
+++ b/src/rules/block/paragraph.ts
@@ -3,7 +3,7 @@ import Token from 'markdown-it/lib/token';
 
 import {MarkdownRenderer} from 'src/renderer';
 
-const interrupters = new Set(['hr', 'heading_close']);
+const interrupters = new Set(['hr', 'heading_close', 'code_block']);
 
 const paragraph: Renderer.RenderRuleRecord = {
     paragraph_open: function (this: MarkdownRenderer, tokens: Token[], i: number) {


### PR DESCRIPTION
[4.4 Indented code blocks](https://spec.commonmark.org/0.30/#indented-code-blocks) rendering 

handle rending paragraph after indented code block

#10 

