### PR TITLE
block-rules: fenced code blocks

### DIFF
--- a/__tests__/rules/markdown-zero-diff.ts
+++ b/__tests__/rules/markdown-zero-diff.ts
@@ -44,6 +44,7 @@ const sectionsKeep = new Set([
     'ATX headings',
     'Setext headings',
     'Indented code blocks',
+    'Fenced code blocks',
 ]);
 
 const examplesOmit = new Set([
@@ -170,6 +171,14 @@ const examplesOmit = new Set([
     113,
     // lists are not implemented
     108, 109,
+
+    // 'Fenced code blocks'
+    // paragraph new lines becomes spaces
+    121,
+    // code_inline leading and trailling spaces are consumed by the parser
+    145,
+    // blockquotes are not implemented
+    128,
 ]);
 
 const units = tests.filter(({section, number}) => {

--- a/src/rules/block/fence.ts
+++ b/src/rules/block/fence.ts
@@ -1,0 +1,113 @@
+import {Options} from 'markdown-it';
+import Renderer from 'markdown-it/lib/renderer';
+import Token from 'markdown-it/lib/token';
+
+import {MarkdownRenderer, MarkdownRendererEnv} from 'src/renderer';
+
+const fence: Renderer.RenderRuleRecord = {
+    fence: fenceHandler,
+};
+
+function fenceHandler(
+    this: MarkdownRenderer,
+    tokens: Token[],
+    i: number,
+    options: Options,
+    env: MarkdownRendererEnv,
+) {
+    const token = tokens[i];
+
+    let rendered = '';
+
+    if (i) {
+        rendered += this.EOL;
+    }
+
+    const [start, end] = token.map ?? [];
+    const {source} = env;
+    if (start !== null && end !== null && end > start && source?.length) {
+        const fenceLines = source.slice(start, end);
+
+        rendered += fenceLines[0];
+
+        // one line fence without close tag
+        // therefore just render open line
+        if (end - start === 1) {
+            return rendered;
+        }
+
+        rendered += this.EOL;
+
+        // render content
+        // (everything but last line)
+        if (token.content?.length) {
+            const left = 1;
+            const right = fenceLines.length > 2 ? fenceLines.length - 1 : fenceLines.length;
+            const originalContent = fenceLines.slice(left, right);
+
+            rendered += originalContent.join('\n');
+            rendered += this.EOL;
+        }
+
+        // close markup is at least of open markup length
+        const parsedFirstLine = parseFence(fenceLines[0]);
+        const parsedLastLine = parseFence(fenceLines[fenceLines.length - 1]);
+        const validCloseMarkupLen =
+            parsedLastLine?.markup?.length >= parsedFirstLine?.markup?.length;
+
+        // fence isn't closed
+        const contentLines = token.content.split('\n').filter(Boolean);
+        const noCloseMarkup =
+            contentLines[contentLines.length - 1] === fenceLines[fenceLines.length - 1];
+
+        // render close markup or last content line
+        if (validCloseMarkupLen || noCloseMarkup) {
+            rendered += fenceLines[fenceLines.length - 1];
+        }
+    }
+
+    return rendered;
+}
+
+function parseFence(str: string) {
+    let i;
+
+    // parse indentation
+    let indentation = 0;
+
+    for (i = 0; i < str.length && str.charAt(i) === ' '; i++);
+
+    indentation = i;
+
+    // parse markup syntax
+    let syntax = '';
+
+    for (i = 0; i < str.length; i++) {
+        const char = str.charAt(i);
+
+        if (char === '`' || char === '~') {
+            syntax = char;
+
+            break;
+        }
+    }
+
+    if (!syntax?.length) {
+        return {succ: false};
+    }
+
+    const markupStart = i;
+
+    for (; str.charAt(i) === syntax; i++);
+
+    const markupEnd = i;
+
+    const markup = str.slice(markupStart, markupEnd);
+
+    const tail = str.slice(i + 1);
+
+    return {indentation, markup, tail};
+}
+
+export {fence};
+export default {fence};

--- a/src/rules/block/index.ts
+++ b/src/rules/block/index.ts
@@ -4,12 +4,14 @@ import {hr} from './hr';
 import {paragraph} from './paragraph';
 import {heading} from './heading';
 import {code} from './code';
+import {fence} from './fence';
 
 const block: Renderer.RenderRuleRecord = {
     ...paragraph,
     ...heading,
     ...hr,
     ...code,
+    ...fence,
 };
 
 export {block};

--- a/src/rules/block/paragraph.ts
+++ b/src/rules/block/paragraph.ts
@@ -3,7 +3,7 @@ import Token from 'markdown-it/lib/token';
 
 import {MarkdownRenderer} from 'src/renderer';
 
-const interrupters = new Set(['hr', 'heading_close', 'code_block']);
+const interrupters = new Set(['hr', 'heading_close', 'code_block', 'fence']);
 
 const paragraph: Renderer.RenderRuleRecord = {
     paragraph_open: function (this: MarkdownRenderer, tokens: Token[], i: number) {


### PR DESCRIPTION
[4.5 Fenced code blocks](https://spec.commonmark.org/0.30/#fenced-code-blocks) #10 

handle paragraph rending after fence block