### PR TITLE
test(rules): semantics markdown snapshot

### DIFF
--- a/__tests__/__helpers__/index.ts
+++ b/__tests__/__helpers__/index.ts
@@ -1,0 +1,4 @@
+// omit first and last empty lines
+const filterOutEmptyFstLst = (line, i, ls) => (i && i + 1 !== ls.length) || line.trim().length;
+
+export const normalizeMD = (str: string) => str.split('\n').filter(filterOutEmptyFstLst).join('\n');

--- a/__tests__/rules/__fixtures__/commonmark.ts
+++ b/__tests__/rules/__fixtures__/commonmark.ts
@@ -1,0 +1,163 @@
+export const semantics = new Set([
+    // 'Backslash escapes',
+    // lost info by the parser, does not change meaning of the constructs
+    22, 23,
+
+    // 'Entity and numeric character references',
+    38,
+    // best we can do is disable link normalization:
+    // md.normalizeLink = id;
+    // gives us same html render
+    32,
+
+    // 'Code spans',
+    // parser strips leading(mostleft), trailling(mostright) space
+    // for code_inline on both sides
+    329, 330, 331, 340, 17,
+
+    // parser treats new lines inside of the code_inline as spaces
+    335, 336, 337,
+
+    // 'Links',
+    // refs are consumed by the parser
+    33, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543,
+    544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562,
+    563, 564, 565, 566, 567, 568, 569, 570,
+
+    // spaces consumed by the parser
+    509,
+    // title quotes are "normalized"
+    505,
+    // by default use double title quotes
+    504,
+    // best we can with html entities see disabling link normalization below
+    502, 499,
+    // < and > are consumed by the parser
+    485, 488, 491, 498,
+    // lost info by the parser, does not change meaing of the constructs
+    494, 497,
+
+    // 'Images'
+    // refs are consumed by the parser
+    572, 575, 576, 581, 582, 583, 584, 585, 586, 587, 588, 589, 590, 591, 592,
+    // < and > are consumed by the parser
+    579,
+    // spaces are consumed by the parser
+    578,
+
+    // 'Hard line breaks',
+    // consumed by the parser, hard line breaks are always \ followed by \n
+    633, 635, 636, 637, 645,
+    // trailling spaces
+    647,
+    // code_inline parser consumes new lines, transforms into spaces
+    641, 640,
+
+    638,
+
+    // 'Soft line breaks',
+    // trailing spaces consumed by the parser
+    649,
+
+    // 'Raw HTML',
+    // paragraphs are not implemented
+
+    // 'Thematic breaks',
+    // spaces are consumed by the parser
+    47, 49, 51, 52, 53, 54, 56, 60, 61,
+
+    // 'Paragraphs'
+    // spaces are consumed by the parser
+    221, 222, 223, 224,
+    // hard line breaks are always transformed into explicit form:
+    // \ followed by a newline
+    226,
+
+    // 'ATX headings'
+    // trailling spaces after heading open syntax are consumed by the parser
+    67, 68, 71, 70,
+    // normalization into heading open syntax always having spacing after
+    // optional heading close syntax are consumed by the parser
+    79, 73, 72,
+
+    // 'Setext headings',
+    // leading, inside the markup, trailling  spaces are consumed by the parser
+    82, 84, 87, 88, 89, 80, 83,
+    // spaces are consumed by the parser
+    105,
+    // intended to fail
+    104,
+
+    // 'Indented code blocks',
+    // trailling spaces consumed by the parser
+    111,
+    // indentation inside paragraph after softbreak is consumed by the parser
+    113,
+
+    108, 109, 117, 118,
+
+    // 'Fenced code blocks'
+    // code_inline spaces and new lines are consumed by the parser
+    145, 121,
+    // normalize not closed fence blocks
+    124, 127, 128, 139, 137, 126, 143,
+
+    // 'HTML blocks',
+    // spaces are consumed by the parser
+    // note: doesn't change semantics(i.e. same html render)
+    // extra spacing after paragraph doesn't change semantics
+    // but helps prevent joining with previous paragraph
+    182, 185, 180, 179, 177, 176, 172, 170, 169, 148,
+
+    174, 175,
+
+    // 'Block quotes'
+    // paragraphs
+    // blockquotes are lazy, semantics preserved
+    228, 229, 241, 233, 249, 243, 251,
+    // we always separate paragraphs
+    248,
+    // we always render spaces that follows blockquote even on empty lines
+    244,
+    // fences
+    // close fences explicitly
+    237,
+    // omit empty lines inside empty blockquote
+    240,
+    // leading spaces consumed by the parser
+    230,
+    // lists are not implemented
+    238,
+
+    // 'List items'
+    253, 254, 255, 256, 258, 259, 260, 262, 263, 268, 272, 273, 274, 275, 276, 277, 279, 280, 282,
+    286, 287, 288, 290, 291, 293, 299, 306, 307, 308, 309, 311, 313, 312, 314, 315, 316, 317, 319,
+    320, 324, 325, 326,
+]);
+
+// commonmark sections
+export const sections = new Set([
+    'Backslash escapes',
+    'Entity and numeric character references',
+    'Inlines',
+    'Code spans',
+    'Links',
+    'Autolinks',
+    'Emphasis and strong emphasis',
+    'Hard line breaks',
+    'Soft line breaks',
+    'Textual content',
+    'Raw HTML',
+    'Images',
+    'Thematic breaks',
+    'Paragraphs',
+    'ATX headings',
+    'Setext headings',
+    'Indented code blocks',
+    'Fenced code blocks',
+    'HTML blocks',
+    'Indented code blocks',
+    'Block quotes',
+    'List items',
+    'Lists',
+]);

--- a/__tests__/rules/__fixtures__/index.ts
+++ b/__tests__/rules/__fixtures__/index.ts
@@ -1,6 +1,2 @@
-export type CommonMarkSpecEntry = {
-    section: string;
-    number: number;
-    markdown: string;
-    html: string;
-};
+export {CommonMarkSpecEntry} from './types';
+export {sections, semantics} from './commonmark';

--- a/__tests__/rules/__fixtures__/types.ts
+++ b/__tests__/rules/__fixtures__/types.ts
@@ -1,0 +1,6 @@
+export type CommonMarkSpecEntry = {
+    section: string;
+    number: number;
+    markdown: string;
+    html: string;
+};

--- a/__tests__/rules/__snapshots__/markdown-semantics.ts.snap
+++ b/__tests__/rules/__snapshots__/markdown-semantics.ts.snap
@@ -1,0 +1,956 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`markdown semantics ATX headings 67 1`] = `"# foo"`;
+
+exports[`markdown semantics ATX headings 68 1`] = `
+"### foo
+## foo
+# foo"
+`;
+
+exports[`markdown semantics ATX headings 70 1`] = `
+"foo
+# bar"
+`;
+
+exports[`markdown semantics ATX headings 71 1`] = `
+"## foo
+### bar"
+`;
+
+exports[`markdown semantics ATX headings 72 1`] = `
+"# foo
+##### foo"
+`;
+
+exports[`markdown semantics ATX headings 73 1`] = `"### foo"`;
+
+exports[`markdown semantics ATX headings 79 1`] = `
+"## 
+# 
+### "
+`;
+
+exports[`markdown semantics Backslash escapes 17 1`] = `"\`\`\\\\[\\\\\`\`\`"`;
+
+exports[`markdown semantics Backslash escapes 22 1`] = `"[foo](/bar* \\"ti*tle\\")"`;
+
+exports[`markdown semantics Backslash escapes 23 1`] = `"[foo](/bar* \\"ti*tle\\")"`;
+
+exports[`markdown semantics Block quotes 228 1`] = `
+"> # Foo
+> bar
+baz"
+`;
+
+exports[`markdown semantics Block quotes 229 1`] = `
+"># Foo
+>bar
+baz"
+`;
+
+exports[`markdown semantics Block quotes 230 1`] = `
+"> # Foo
+> bar
+baz"
+`;
+
+exports[`markdown semantics Block quotes 233 1`] = `
+"> bar
+baz
+foo"
+`;
+
+exports[`markdown semantics Block quotes 237 1`] = `
+"> \`\`\`
+> \`\`\`
+
+
+foo
+\`\`\`
+\`\`\`"
+`;
+
+exports[`markdown semantics Block quotes 238 1`] = `
+"> foo
+- bar"
+`;
+
+exports[`markdown semantics Block quotes 240 1`] = `">"`;
+
+exports[`markdown semantics Block quotes 241 1`] = `">foo"`;
+
+exports[`markdown semantics Block quotes 243 1`] = `
+"> foo
+bar"
+`;
+
+exports[`markdown semantics Block quotes 244 1`] = `
+"> foo
+> 
+> bar"
+`;
+
+exports[`markdown semantics Block quotes 248 1`] = `
+"> bar
+
+
+baz"
+`;
+
+exports[`markdown semantics Block quotes 249 1`] = `
+"> bar
+
+
+baz"
+`;
+
+exports[`markdown semantics Block quotes 251 1`] = `
+">>> foo
+bar
+baz"
+`;
+
+exports[`markdown semantics Code spans 329 1`] = `"\`\`foo \` bar\`\`"`;
+
+exports[`markdown semantics Code spans 330 1`] = `"\`\`\`\`"`;
+
+exports[`markdown semantics Code spans 331 1`] = `"\` \`\` \`"`;
+
+exports[`markdown semantics Code spans 335 1`] = `"\`\`foo bar   baz\`\`"`;
+
+exports[`markdown semantics Code spans 336 1`] = `"\`\`foo \`\`"`;
+
+exports[`markdown semantics Code spans 337 1`] = `"\`foo   bar  baz\`"`;
+
+exports[`markdown semantics Code spans 340 1`] = `"\`foo \`\` bar\`"`;
+
+exports[`markdown semantics Entity and numeric character references 32 1`] = `"[foo](/föö \\"föö\\")"`;
+
+exports[`markdown semantics Entity and numeric character references 33 1`] = `"[foo](/föö \\"föö\\")"`;
+
+exports[`markdown semantics Entity and numeric character references 38 1`] = `
+"&#42; foo
+* foo"
+`;
+
+exports[`markdown semantics Fenced code blocks 121 1`] = `"\`\`foo\`\`"`;
+
+exports[`markdown semantics Fenced code blocks 124 1`] = `
+"\`\`\`\`
+aaa
+\`\`\`
+\`\`\`\`\`\`"
+`;
+
+exports[`markdown semantics Fenced code blocks 126 1`] = `
+"\`\`\`
+\`\`\`"
+`;
+
+exports[`markdown semantics Fenced code blocks 127 1`] = `
+"\`\`\`\`\`
+
+\`\`\`
+\`\`\`\`\`"
+`;
+
+exports[`markdown semantics Fenced code blocks 128 1`] = `
+"> \`\`\`
+> aaa
+> \`\`\`
+
+
+bbb"
+`;
+
+exports[`markdown semantics Fenced code blocks 137 1`] = `
+"\`\`\`
+aaa
+    \`\`\`"
+`;
+
+exports[`markdown semantics Fenced code blocks 139 1`] = `
+"~~~~~~
+aaa
+~~~"
+`;
+
+exports[`markdown semantics Fenced code blocks 143 1`] = `
+"~~~~    ruby startline=3 $%@#$
+def foo(x)
+  return 3
+end
+~~~~~~~"
+`;
+
+exports[`markdown semantics Fenced code blocks 145 1`] = `
+"\`\`\`aa\`\`\`
+foo"
+`;
+
+exports[`markdown semantics HTML blocks 148 1`] = `
+"<table><tr><td>
+<pre>
+**Hello**,
+
+_world_.
+</pre>
+
+</td></tr></table>"
+`;
+
+exports[`markdown semantics HTML blocks 169 1`] = `
+"<pre language=\\"haskell\\"><code>
+import Text.HTML.TagSoup
+
+main :: IO ()
+main = print $ parseTags tags
+</code></pre>
+
+okay"
+`;
+
+exports[`markdown semantics HTML blocks 170 1`] = `
+"<script type=\\"text/javascript\\">
+// JavaScript example
+
+document.getElementById(\\"demo\\").innerHTML = \\"Hello JavaScript!\\";
+</script>
+
+okay"
+`;
+
+exports[`markdown semantics HTML blocks 172 1`] = `
+"<style
+  type=\\"text/css\\">
+h1 {color:red;}
+
+p {color:blue;}
+</style>
+
+okay"
+`;
+
+exports[`markdown semantics HTML blocks 174 1`] = `
+"
+> <div>
+> foo
+
+
+bar"
+`;
+
+exports[`markdown semantics HTML blocks 175 1`] = `
+"
+- <div>
+- foo"
+`;
+
+exports[`markdown semantics HTML blocks 176 1`] = `
+"<style>p{color:red;}</style>
+
+*foo*"
+`;
+
+exports[`markdown semantics HTML blocks 177 1`] = `
+"<!-- foo -->*bar*
+
+*baz*"
+`;
+
+exports[`markdown semantics HTML blocks 179 1`] = `
+"<!-- Foo
+
+bar
+   baz -->
+
+okay"
+`;
+
+exports[`markdown semantics HTML blocks 180 1`] = `
+"<?php
+
+  echo '>';
+
+?>
+
+okay"
+`;
+
+exports[`markdown semantics HTML blocks 182 1`] = `
+"<![CDATA[
+function matchwo(a,b)
+{
+  if (a < b && a < 0) then {
+    return 1;
+
+  } else {
+
+    return 0;
+  }
+}
+]]>
+
+okay"
+`;
+
+exports[`markdown semantics HTML blocks 185 1`] = `
+"Foo
+
+<div>
+bar
+</div>"
+`;
+
+exports[`markdown semantics Hard line breaks 633 1`] = `
+"foo\\\\
+baz"
+`;
+
+exports[`markdown semantics Hard line breaks 635 1`] = `
+"foo\\\\
+baz"
+`;
+
+exports[`markdown semantics Hard line breaks 636 1`] = `
+"foo\\\\
+bar"
+`;
+
+exports[`markdown semantics Hard line breaks 637 1`] = `
+"foo\\\\
+bar"
+`;
+
+exports[`markdown semantics Hard line breaks 638 1`] = `
+"*foo\\\\
+bar*"
+`;
+
+exports[`markdown semantics Hard line breaks 640 1`] = `"\`code   span\`"`;
+
+exports[`markdown semantics Hard line breaks 641 1`] = `"\`code\\\\ span\`"`;
+
+exports[`markdown semantics Hard line breaks 645 1`] = `"foo"`;
+
+exports[`markdown semantics Hard line breaks 647 1`] = `"### foo"`;
+
+exports[`markdown semantics Images 572 1`] = `"![foo *bar*](train.jpg \\"train & tracks\\")"`;
+
+exports[`markdown semantics Images 575 1`] = `"![foo *bar*](train.jpg \\"train & tracks\\")"`;
+
+exports[`markdown semantics Images 576 1`] = `"![foo *bar*](train.jpg \\"train & tracks\\")"`;
+
+exports[`markdown semantics Images 578 1`] = `"My ![foo bar](/path/to/train.jpg \\"title\\")"`;
+
+exports[`markdown semantics Images 579 1`] = `"![foo](url)"`;
+
+exports[`markdown semantics Images 581 1`] = `"![foo](/url)"`;
+
+exports[`markdown semantics Images 582 1`] = `"![foo](/url)"`;
+
+exports[`markdown semantics Images 583 1`] = `"![foo](/url \\"title\\")"`;
+
+exports[`markdown semantics Images 584 1`] = `"![*foo* bar](/url \\"title\\")"`;
+
+exports[`markdown semantics Images 585 1`] = `"![Foo](/url \\"title\\")"`;
+
+exports[`markdown semantics Images 586 1`] = `
+"![foo](/url \\"title\\")
+[]"
+`;
+
+exports[`markdown semantics Images 587 1`] = `"![foo](/url \\"title\\")"`;
+
+exports[`markdown semantics Images 588 1`] = `"![*foo* bar](/url \\"title\\")"`;
+
+exports[`markdown semantics Images 589 1`] = `
+"![[foo]]
+
+[[foo]]: /url \\"title\\""
+`;
+
+exports[`markdown semantics Images 590 1`] = `"![Foo](/url \\"title\\")"`;
+
+exports[`markdown semantics Images 591 1`] = `"!\\\\[foo](/url \\"title\\")"`;
+
+exports[`markdown semantics Images 592 1`] = `"\\\\![foo](/url \\"title\\")"`;
+
+exports[`markdown semantics Indented code blocks 108 1`] = `
+"  - foo
+    
+    bar"
+`;
+
+exports[`markdown semantics Indented code blocks 109 1`] = `
+"1.  foo
+    - bar"
+`;
+
+exports[`markdown semantics Indented code blocks 111 1`] = `
+"    chunk1
+
+    chunk2
+
+
+
+    chunk3"
+`;
+
+exports[`markdown semantics Indented code blocks 113 1`] = `
+"Foo
+bar"
+`;
+
+exports[`markdown semantics Indented code blocks 117 1`] = `"    foo"`;
+
+exports[`markdown semantics Indented code blocks 118 1`] = `"    foo"`;
+
+exports[`markdown semantics Links 485 1`] = `"[link]()"`;
+
+exports[`markdown semantics Links 488 1`] = `"[link](/my uri)"`;
+
+exports[`markdown semantics Links 491 1`] = `"[a](b)c)"`;
+
+exports[`markdown semantics Links 494 1`] = `"[link]((foo))"`;
+
+exports[`markdown semantics Links 497 1`] = `"[link](foo(and(bar))"`;
+
+exports[`markdown semantics Links 498 1`] = `"[link](foo(and(bar))"`;
+
+exports[`markdown semantics Links 499 1`] = `"[link](foo):)"`;
+
+exports[`markdown semantics Links 502 1`] = `"[link](foo%20bä)"`;
+
+exports[`markdown semantics Links 504 1`] = `
+"[link](/url \\"title\\")
+[link](/url \\"title\\")
+[link](/url \\"title\\")"
+`;
+
+exports[`markdown semantics Links 505 1`] = `"[link](/url 'title \\"\\"')"`;
+
+exports[`markdown semantics Links 509 1`] = `"[link](/uri \\"title\\")"`;
+
+exports[`markdown semantics Links 526 1`] = `"[foo](/url \\"title\\")"`;
+
+exports[`markdown semantics Links 527 1`] = `"[link [foo [bar]]](/uri)"`;
+
+exports[`markdown semantics Links 528 1`] = `"[link \\\\[bar](/uri)"`;
+
+exports[`markdown semantics Links 529 1`] = `"[link *foo **bar** \`#\`*](/uri)"`;
+
+exports[`markdown semantics Links 530 1`] = `"[![moon](moon.jpg)](/uri)"`;
+
+exports[`markdown semantics Links 531 1`] = `"[foo [bar](/uri)][ref](/uri)"`;
+
+exports[`markdown semantics Links 532 1`] = `"[foo *bar [baz](/uri)*][ref](/uri)"`;
+
+exports[`markdown semantics Links 533 1`] = `"*[foo*](/uri)"`;
+
+exports[`markdown semantics Links 534 1`] = `"[foo *bar](/uri)*"`;
+
+exports[`markdown semantics Links 535 1`] = `"[foo <bar attr=\\"][ref]\\">"`;
+
+exports[`markdown semantics Links 536 1`] = `"[foo\`][ref]\`"`;
+
+exports[`markdown semantics Links 537 1`] = `"[foo<http://example.com/?search=][ref]>"`;
+
+exports[`markdown semantics Links 538 1`] = `"[foo](/url \\"title\\")"`;
+
+exports[`markdown semantics Links 539 1`] = `"[ẞ](/url)"`;
+
+exports[`markdown semantics Links 540 1`] = `"[Baz](/url)"`;
+
+exports[`markdown semantics Links 541 1`] = `"[foo] [bar](/url \\"title\\")"`;
+
+exports[`markdown semantics Links 542 1`] = `
+"[foo]
+[bar](/url \\"title\\")"
+`;
+
+exports[`markdown semantics Links 543 1`] = `"[bar](/url1)"`;
+
+exports[`markdown semantics Links 544 1`] = `"[bar][foo\\\\!]"`;
+
+exports[`markdown semantics Links 545 1`] = `
+"[foo][ref[]
+
+[ref[]: /uri"
+`;
+
+exports[`markdown semantics Links 546 1`] = `
+"[foo][ref[bar]]
+
+[ref[bar]]: /uri"
+`;
+
+exports[`markdown semantics Links 547 1`] = `
+"[[[foo]]]
+
+[[[foo]]]: /url"
+`;
+
+exports[`markdown semantics Links 548 1`] = `"[foo][ref\\\\[]"`;
+
+exports[`markdown semantics Links 549 1`] = `"[bar\\\\\\\\](/uri)"`;
+
+exports[`markdown semantics Links 550 1`] = `
+"[]
+
+[]: /uri"
+`;
+
+exports[`markdown semantics Links 551 1`] = `
+"[
+]
+
+[
+]: /uri"
+`;
+
+exports[`markdown semantics Links 552 1`] = `"[foo](/url \\"title\\")"`;
+
+exports[`markdown semantics Links 553 1`] = `"[*foo* bar](/url \\"title\\")"`;
+
+exports[`markdown semantics Links 554 1`] = `"[Foo](/url \\"title\\")"`;
+
+exports[`markdown semantics Links 555 1`] = `
+"[foo](/url \\"title\\")
+[]"
+`;
+
+exports[`markdown semantics Links 556 1`] = `"[foo](/url \\"title\\")"`;
+
+exports[`markdown semantics Links 557 1`] = `"[*foo* bar](/url \\"title\\")"`;
+
+exports[`markdown semantics Links 558 1`] = `"[[*foo* bar](/url \\"title\\")]"`;
+
+exports[`markdown semantics Links 559 1`] = `"[[bar [foo](/url)"`;
+
+exports[`markdown semantics Links 560 1`] = `"[Foo](/url \\"title\\")"`;
+
+exports[`markdown semantics Links 561 1`] = `"[foo](/url) bar"`;
+
+exports[`markdown semantics Links 562 1`] = `"\\\\[foo](/url \\"title\\")"`;
+
+exports[`markdown semantics Links 563 1`] = `"*[foo*](/url)"`;
+
+exports[`markdown semantics Links 564 1`] = `"[foo](/url2)"`;
+
+exports[`markdown semantics Links 565 1`] = `"[foo](/url1)"`;
+
+exports[`markdown semantics Links 566 1`] = `"[foo]()"`;
+
+exports[`markdown semantics Links 567 1`] = `"[foo](/url1)(not a link)"`;
+
+exports[`markdown semantics Links 568 1`] = `"[foo][bar](/url)"`;
+
+exports[`markdown semantics Links 569 1`] = `"[foo](/url2)[baz](/url1)"`;
+
+exports[`markdown semantics Links 570 1`] = `"[foo][bar](/url1)"`;
+
+exports[`markdown semantics List items 253 1`] = `
+"A paragraph
+with two lines.
+
+    indented code
+> A block quote."
+`;
+
+exports[`markdown semantics List items 254 1`] = `
+"1.  A paragraph
+with two lines.
+
+        indented code
+    > A block quote."
+`;
+
+exports[`markdown semantics List items 255 1`] = `
+"- one
+
+two"
+`;
+
+exports[`markdown semantics List items 256 1`] = `
+"- one
+  
+  two"
+`;
+
+exports[`markdown semantics List items 258 1`] = `
+" -    one
+      
+      two"
+`;
+
+exports[`markdown semantics List items 259 1`] = `
+"> >  1.  one
+> >      
+> >      two"
+`;
+
+exports[`markdown semantics List items 260 1`] = `
+">>- one
+>>
+>>two"
+`;
+
+exports[`markdown semantics List items 262 1`] = `
+"- foo
+  
+  bar"
+`;
+
+exports[`markdown semantics List items 263 1`] = `
+"1.  foo
+    \`\`\`
+    bar
+    \`\`\`
+    baz
+    > bam"
+`;
+
+exports[`markdown semantics List items 268 1`] = `"3. ok"`;
+
+exports[`markdown semantics List items 272 1`] = `
+"    indented code
+paragraph
+
+    more code"
+`;
+
+exports[`markdown semantics List items 273 1`] = `
+"1.     indented code
+   paragraph
+
+       more code"
+`;
+
+exports[`markdown semantics List items 274 1`] = `
+"1.      indented code
+   paragraph
+
+       more code"
+`;
+
+exports[`markdown semantics List items 275 1`] = `
+"foo
+
+bar"
+`;
+
+exports[`markdown semantics List items 276 1`] = `
+"-    foo
+
+bar"
+`;
+
+exports[`markdown semantics List items 277 1`] = `
+"-  foo
+   
+   bar"
+`;
+
+exports[`markdown semantics List items 279 1`] = `
+"-
+  foo"
+`;
+
+exports[`markdown semantics List items 280 1`] = `
+"-
+
+foo"
+`;
+
+exports[`markdown semantics List items 282 1`] = `
+"- foo
+-
+- bar"
+`;
+
+exports[`markdown semantics List items 286 1`] = `
+" 1.  A paragraph
+with two lines.
+
+         indented code
+     > A block quote."
+`;
+
+exports[`markdown semantics List items 287 1`] = `
+"  1.  A paragraph
+with two lines.
+
+          indented code
+      > A block quote."
+`;
+
+exports[`markdown semantics List items 288 1`] = `
+"   1.  A paragraph
+with two lines.
+
+           indented code
+       > A block quote."
+`;
+
+exports[`markdown semantics List items 290 1`] = `
+"  1.  A paragraph
+with two lines.
+
+          indented code
+      > A block quote."
+`;
+
+exports[`markdown semantics List items 291 1`] = `
+"  1.  A paragraph
+with two lines."
+`;
+
+exports[`markdown semantics List items 293 1`] = `
+"> 1. > Blockquote
+continued here."
+`;
+
+exports[`markdown semantics List items 299 1`] = `"1. - 1. foo"`;
+
+exports[`markdown semantics Lists 306 1`] = `
+"- foo
+- bar
+- baz"
+`;
+
+exports[`markdown semantics Lists 307 1`] = `
+"- foo
+  - bar
+    - baz
+      
+      bim"
+`;
+
+exports[`markdown semantics Lists 308 1`] = `
+"- foo
+- bar
+<!-- -->
+- baz
+- bim"
+`;
+
+exports[`markdown semantics Lists 309 1`] = `
+"-   foo
+    
+    notcode
+-   foo
+<!-- -->
+
+    code"
+`;
+
+exports[`markdown semantics Lists 311 1`] = `
+"1. a
+  2. b
+   3. c"
+`;
+
+exports[`markdown semantics Lists 312 1`] = `
+"- a
+ - b
+  - c
+   - d
+- e"
+`;
+
+exports[`markdown semantics Lists 313 1`] = `
+"1. a
+  2. b
+    3. c"
+`;
+
+exports[`markdown semantics Lists 314 1`] = `
+"- a
+- b
+- c"
+`;
+
+exports[`markdown semantics Lists 315 1`] = `
+"* a
+*
+* c"
+`;
+
+exports[`markdown semantics Lists 316 1`] = `
+"- a
+- b
+  
+  c
+- d"
+`;
+
+exports[`markdown semantics Lists 317 1`] = `
+"- a
+- b
+- d"
+`;
+
+exports[`markdown semantics Lists 319 1`] = `
+"- a
+  - b
+    
+    c
+- d"
+`;
+
+exports[`markdown semantics Lists 320 1`] = `
+"* a
+  > b
+* c"
+`;
+
+exports[`markdown semantics Lists 324 1`] = `
+"1. \`\`\`
+   foo
+   \`\`\`
+   bar"
+`;
+
+exports[`markdown semantics Lists 325 1`] = `
+"* foo
+  * bar
+  
+  baz"
+`;
+
+exports[`markdown semantics Lists 326 1`] = `
+"- a
+  - b
+  - c
+- d
+  - e
+  - f"
+`;
+
+exports[`markdown semantics Paragraphs 221 1`] = `
+"aaa
+
+bbb"
+`;
+
+exports[`markdown semantics Paragraphs 222 1`] = `
+"aaa
+bbb"
+`;
+
+exports[`markdown semantics Paragraphs 223 1`] = `
+"aaa
+bbb
+ccc"
+`;
+
+exports[`markdown semantics Paragraphs 224 1`] = `
+"aaa
+bbb"
+`;
+
+exports[`markdown semantics Paragraphs 226 1`] = `
+"aaa\\\\
+bbb"
+`;
+
+exports[`markdown semantics Setext headings 80 1`] = `
+"Foo *bar*
+=========
+Foo *bar*
+---------"
+`;
+
+exports[`markdown semantics Setext headings 82 1`] = `
+"Foo *bar
+baz*→
+===="
+`;
+
+exports[`markdown semantics Setext headings 83 1`] = `
+"Foo
+-------------------------
+Foo
+="
+`;
+
+exports[`markdown semantics Setext headings 84 1`] = `
+"Foo
+---
+Foo
+-----
+Foo
+  ==="
+`;
+
+exports[`markdown semantics Setext headings 87 1`] = `
+"Foo
+---"
+`;
+
+exports[`markdown semantics Setext headings 88 1`] = `
+"Foo
+= =
+
+Foo
+----"
+`;
+
+exports[`markdown semantics Setext headings 89 1`] = `
+"Foo
+-----"
+`;
+
+exports[`markdown semantics Setext headings 104 1`] = `
+"Foo
+bar
+---
+baz"
+`;
+
+exports[`markdown semantics Setext headings 105 1`] = `
+"Foo
+bar
+***
+baz"
+`;
+
+exports[`markdown semantics Soft line breaks 649 1`] = `
+"foo
+baz"
+`;
+
+exports[`markdown semantics Thematic breaks 47 1`] = `
+"***
+***
+***"
+`;
+
+exports[`markdown semantics Thematic breaks 49 1`] = `
+"Foo
+***"
+`;
+
+exports[`markdown semantics Thematic breaks 51 1`] = `"---"`;
+
+exports[`markdown semantics Thematic breaks 52 1`] = `"***********"`;
+
+exports[`markdown semantics Thematic breaks 53 1`] = `"----"`;
+
+exports[`markdown semantics Thematic breaks 54 1`] = `"----"`;
+
+exports[`markdown semantics Thematic breaks 56 1`] = `"*-*"`;
+
+exports[`markdown semantics Thematic breaks 60 1`] = `
+"* Foo
+***
+* Bar"
+`;
+
+exports[`markdown semantics Thematic breaks 61 1`] = `
+"- Foo
+***
+-"
+`;

--- a/__tests__/rules/markdown-semantics.ts
+++ b/__tests__/rules/markdown-semantics.ts
@@ -1,0 +1,54 @@
+import MarkdownIt from 'markdown-it';
+import {MarkdownRenderer, MarkdownRendererEnv, MarkdownRendererMode} from 'src/renderer';
+import {tests} from 'commonmark-spec';
+
+import {semanticsTests} from './markdown-zero-diff';
+
+import {CommonMarkSpecEntry} from './__fixtures__';
+
+const renderer = new MarkdownRenderer({mode: MarkdownRendererMode.Production});
+
+const md = new MarkdownIt('commonmark', {html: true});
+
+// helpers
+// always evaluate to provided value <v>
+const always = (v: boolean) => () => v;
+// always return input value <a> as a result
+const id = (a: string) => a;
+
+// modify markdown-it parser behaviour
+// disable escape rule
+md.inline.ruler.at('escape', always(false));
+// disable entity rule
+md.inline.ruler.at('entity', always(false));
+// disable links normalization
+md.normalizeLink = id;
+
+// @ts-ignore
+md.renderer = renderer;
+
+const units = tests.filter(({number}) => semanticsTests.has(number));
+
+const filterOutEmptyFstLst = (line, i, ls) => (i && i + 1 !== ls.length) || line.trim().length;
+const normalizeMD = (str: string) => str.split('\n').filter(filterOutEmptyFstLst).join('\n');
+
+console.log = (a) => a;
+console.info = (a) => a;
+
+describe('markdown semantics', () => {
+    units.forEach((entry: CommonMarkSpecEntry) => {
+        const {section, number, markdown} = entry;
+
+        const name = `${section} ${number}`;
+
+        test(name, () => {
+            // passing array of original markdown string split by new lines
+            const env: MarkdownRendererEnv = {source: markdown.split('\n')};
+            const rendered = md.render(markdown, env);
+
+            const actual = normalizeMD(rendered);
+
+            expect(actual).toMatchSnapshot();
+        });
+    });
+});

--- a/__tests__/rules/markdown-semantics.ts
+++ b/__tests__/rules/markdown-semantics.ts
@@ -2,14 +2,14 @@ import MarkdownIt from 'markdown-it';
 import {MarkdownRenderer, MarkdownRendererEnv, MarkdownRendererMode} from 'src/renderer';
 import {tests} from 'commonmark-spec';
 
-import {semanticsTests} from './markdown-zero-diff';
-
-import {CommonMarkSpecEntry} from './__fixtures__';
+import {semantics, CommonMarkSpecEntry} from './__fixtures__';
+import {normalizeMD} from '__tests__/__helpers__';
 
 const renderer = new MarkdownRenderer({mode: MarkdownRendererMode.Production});
 
 const md = new MarkdownIt('commonmark', {html: true});
 
+// todo: refactor into new interface
 // helpers
 // always evaluate to provided value <v>
 const always = (v: boolean) => () => v;
@@ -27,11 +27,10 @@ md.normalizeLink = id;
 // @ts-ignore
 md.renderer = renderer;
 
-const units = tests.filter(({number}) => semanticsTests.has(number));
+const units = tests.filter(({number}) => semantics.has(number));
 
-const filterOutEmptyFstLst = (line, i, ls) => (i && i + 1 !== ls.length) || line.trim().length;
-const normalizeMD = (str: string) => str.split('\n').filter(filterOutEmptyFstLst).join('\n');
-
+// todo: remove unnecessary logging
+// for now suppress it
 console.log = (a) => a;
 console.info = (a) => a;
 

--- a/__tests__/rules/markdown-zero-diff.ts
+++ b/__tests__/rules/markdown-zero-diff.ts
@@ -46,20 +46,18 @@ const sectionsKeep = new Set([
     'Indented code blocks',
     'Fenced code blocks',
     'HTML blocks',
+    'Indented code blocks',
     'Block quotes',
+    'List items',
+    'Lists',
 ]);
 
-const examplesOmit = new Set([
+export const semanticsTests = new Set([
     // 'Backslash escapes',
-    // fence is not implemented
-    19, 34, 36,
-    // tabulated code block not implemented
-    18,
     // lost info by the parser, does not change meaning of the constructs
-    22, 23, 24,
+    22, 23,
 
     // 'Entity and numeric character references',
-    // lists are not implemented
     38,
     // best we can do is disable link normalization:
     // md.normalizeLink = id;
@@ -70,6 +68,7 @@ const examplesOmit = new Set([
     // parser strips leading(mostleft), trailling(mostright) space
     // for code_inline on both sides
     329, 330, 331, 340, 17,
+
     // parser treats new lines inside of the code_inline as spaces
     335, 336, 337,
 
@@ -78,6 +77,7 @@ const examplesOmit = new Set([
     33, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543,
     544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562,
     563, 564, 565, 566, 567, 568, 569, 570,
+
     // spaces consumed by the parser
     509,
     // title quotes are "normalized"
@@ -101,12 +101,12 @@ const examplesOmit = new Set([
 
     // 'Hard line breaks',
     // consumed by the parser, hard line breaks are always \ followed by \n
-    633, 635, 636, 637,
-    // headings are not implemented
-    646, 647,
+    633, 635, 636, 637, 645,
+    // trailling spaces
+    647,
     // code_inline parser consumes new lines, transforms into spaces
     641, 640,
-    // lists are not implemented
+
     638,
 
     // 'Soft line breaks',
@@ -115,52 +115,30 @@ const examplesOmit = new Set([
 
     // 'Raw HTML',
     // paragraphs are not implemented
-    626,
 
     // 'Thematic breaks',
-    // lists are not implemented
-    57, 60, 61,
-    // headers are not implemented
-    59,
-    // leading spaces are consumed by the parser
-    49,
-
-    // code indent blocks are not implemented
-    48,
-    // spaces consumed by the parser
-    47, 51, 52, 53, 54,
+    // spaces are consumed by the parser
+    47, 49, 51, 52, 53, 54, 56, 60, 61,
 
     // 'Paragraphs'
-    // spaces between blocks are consumed by the parser
-    221,
+    // spaces are consumed by the parser
+    221, 222, 223, 224,
     // hard line breaks are always transformed into explicit form:
     // \ followed by a newline
     226,
-    // code indent blocks are not implemented
-    225,
-    // leading spaces are consumed by the parser
-    222, 223,
 
     // 'ATX headings'
     // trailling spaces after heading open syntax are consumed by the parser
-    67,
+    67, 68, 71, 70,
     // normalization into heading open syntax always having spacing after
     // optional heading close syntax are consumed by the parser
     79, 73, 72,
-    // optional indentation before heading open syntax consumed by the parser
-    71, 70, 68,
-    // test intended to fail
-    69,
 
     // 'Setext headings',
     // leading, inside the markup, trailling  spaces are consumed by the parser
-    84, 87, 88, 89, 80, 83,
+    82, 84, 87, 88, 89, 80, 83,
     // spaces are consumed by the parser
     105,
-    // indented code block are not implemented
-    85, 100,
-    // lists are not implemented
-    99, 94,
     // intended to fail
     104,
 
@@ -169,37 +147,28 @@ const examplesOmit = new Set([
     111,
     // indentation inside paragraph after softbreak is consumed by the parser
     113,
-    // lists are not implemented
-    108, 109,
+
+    108, 109, 117, 118,
 
     // 'Fenced code blocks'
-    // paragraph new lines becomes spaces
-    121,
-    // code_inline leading and trailling spaces are consumed by the parser
-    145,
-    // semantics are the same
-    128,
+    // code_inline spaces and new lines are consumed by the parser
+    145, 121,
     // normalize not closed fence blocks
-    139, 137, 126, 127,
-    // normalize markup close different from markup open
-    124, 143,
+    124, 127, 128, 139, 137, 126, 143,
 
     // 'HTML blocks',
     // spaces are consumed by the parser
     // note: doesn't change semantics(i.e. same html render)
-    152,
     // extra spacing after paragraph doesn't change semantics
     // but helps prevent joining with previous paragraph
-    182, 185, 188, 180, 179, 177, 176, 172, 170, 169, 148,
-    // lists are not implemented
-    175,
-    // semantics are the same
-    174,
+    182, 185, 180, 179, 177, 176, 172, 170, 169, 148,
+
+    174, 175,
 
     // 'Block quotes'
     // paragraphs
     // blockquotes are lazy, semantics preserved
-    251, 249, 233, 243, 241,
+    228, 229, 241, 233, 249, 243, 251,
     // we always separate paragraphs
     248,
     // we always render spaces that follows blockquote even on empty lines
@@ -209,26 +178,42 @@ const examplesOmit = new Set([
     237,
     // omit empty lines inside empty blockquote
     240,
-    // headers
-    // lazy blockquotes inside paragraphs
-    228, 229,
     // leading spaces consumed by the parser
     230,
     // lists are not implemented
-    238, 235,
+    238,
+
+    // 'List items'
+    253, 254, 255, 256, 258, 259, 260, 262, 263, 268, 272, 273, 274, 275, 276, 277, 279, 280, 282,
+    286, 287, 288, 290, 291, 293, 299, 306, 307, 308, 309, 311, 313, 312, 314, 315, 316, 317, 319,
+    320, 324, 325, 326,
 ]);
 
 const units = tests.filter(({section, number}) => {
+    const cond = semanticsTests.has(number);
+
+    // return cond;
+    if (cond) {
+        return false;
+    }
+
     if (!sectionsKeep.has(section)) {
         return false;
     }
 
-    if (examplesOmit.has(number)) {
+    if (sectionsKeep.has(number)) {
         return false;
     }
 
     return true;
 });
+
+// omit first and last empty lines
+const filterOutEmptyFstLst = (line, i, ls) => (i && i + 1 !== ls.length) || line.trim().length;
+const normalizeMD = (str: string) => str.split('\n').filter(filterOutEmptyFstLst).join('\n');
+
+console.info = (a) => a;
+console.log = (a) => a;
 
 describe('markdown zero diff', () => {
     units.forEach((entry: CommonMarkSpecEntry) => {
@@ -241,7 +226,7 @@ describe('markdown zero diff', () => {
             const env: MarkdownRendererEnv = {source: markdown.split('\n')};
             const rendered = md.render(markdown, env);
 
-            expect(rendered.trim()).toStrictEqual(markdown.trim());
+            expect(normalizeMD(rendered)).toStrictEqual(normalizeMD(markdown));
         });
     });
 });

--- a/__tests__/rules/markdown-zero-diff.ts
+++ b/__tests__/rules/markdown-zero-diff.ts
@@ -2,12 +2,14 @@ import MarkdownIt from 'markdown-it';
 import {MarkdownRenderer, MarkdownRendererEnv, MarkdownRendererMode} from 'src/renderer';
 import {tests} from 'commonmark-spec';
 
-import {CommonMarkSpecEntry} from './__fixtures__';
+import {sections, semantics, CommonMarkSpecEntry} from './__fixtures__';
+import {normalizeMD} from '__tests__/__helpers__';
 
 const renderer = new MarkdownRenderer({mode: MarkdownRendererMode.Production});
 
 const md = new MarkdownIt('commonmark', {html: true});
 
+// todo: refactor into new interface
 // helpers
 // always evaluate to provided value <v>
 const always = (v: boolean) => () => v;
@@ -25,193 +27,24 @@ md.normalizeLink = id;
 // @ts-ignore
 md.renderer = renderer;
 
-// test only rules that are implemented
-const sectionsKeep = new Set([
-    'Backslash escapes',
-    'Entity and numeric character references',
-    'Inlines',
-    'Code spans',
-    'Links',
-    'Autolinks',
-    'Emphasis and strong emphasis',
-    'Hard line breaks',
-    'Soft line breaks',
-    'Textual content',
-    'Raw HTML',
-    'Images',
-    'Thematic breaks',
-    'Paragraphs',
-    'ATX headings',
-    'Setext headings',
-    'Indented code blocks',
-    'Fenced code blocks',
-    'HTML blocks',
-    'Indented code blocks',
-    'Block quotes',
-    'List items',
-    'Lists',
-]);
-
-export const semanticsTests = new Set([
-    // 'Backslash escapes',
-    // lost info by the parser, does not change meaning of the constructs
-    22, 23,
-
-    // 'Entity and numeric character references',
-    38,
-    // best we can do is disable link normalization:
-    // md.normalizeLink = id;
-    // gives us same html render
-    32,
-
-    // 'Code spans',
-    // parser strips leading(mostleft), trailling(mostright) space
-    // for code_inline on both sides
-    329, 330, 331, 340, 17,
-
-    // parser treats new lines inside of the code_inline as spaces
-    335, 336, 337,
-
-    // 'Links',
-    // refs are consumed by the parser
-    33, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543,
-    544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562,
-    563, 564, 565, 566, 567, 568, 569, 570,
-
-    // spaces consumed by the parser
-    509,
-    // title quotes are "normalized"
-    505,
-    // by default use double title quotes
-    504,
-    // best we can with html entities see disabling link normalization below
-    502, 499,
-    // < and > are consumed by the parser
-    485, 488, 491, 498,
-    // lost info by the parser, does not change meaing of the constructs
-    494, 497,
-
-    // 'Images'
-    // refs are consumed by the parser
-    572, 575, 576, 581, 582, 583, 584, 585, 586, 587, 588, 589, 590, 591, 592,
-    // < and > are consumed by the parser
-    579,
-    // spaces are consumed by the parser
-    578,
-
-    // 'Hard line breaks',
-    // consumed by the parser, hard line breaks are always \ followed by \n
-    633, 635, 636, 637, 645,
-    // trailling spaces
-    647,
-    // code_inline parser consumes new lines, transforms into spaces
-    641, 640,
-
-    638,
-
-    // 'Soft line breaks',
-    // trailing spaces consumed by the parser
-    649,
-
-    // 'Raw HTML',
-    // paragraphs are not implemented
-
-    // 'Thematic breaks',
-    // spaces are consumed by the parser
-    47, 49, 51, 52, 53, 54, 56, 60, 61,
-
-    // 'Paragraphs'
-    // spaces are consumed by the parser
-    221, 222, 223, 224,
-    // hard line breaks are always transformed into explicit form:
-    // \ followed by a newline
-    226,
-
-    // 'ATX headings'
-    // trailling spaces after heading open syntax are consumed by the parser
-    67, 68, 71, 70,
-    // normalization into heading open syntax always having spacing after
-    // optional heading close syntax are consumed by the parser
-    79, 73, 72,
-
-    // 'Setext headings',
-    // leading, inside the markup, trailling  spaces are consumed by the parser
-    82, 84, 87, 88, 89, 80, 83,
-    // spaces are consumed by the parser
-    105,
-    // intended to fail
-    104,
-
-    // 'Indented code blocks',
-    // trailling spaces consumed by the parser
-    111,
-    // indentation inside paragraph after softbreak is consumed by the parser
-    113,
-
-    108, 109, 117, 118,
-
-    // 'Fenced code blocks'
-    // code_inline spaces and new lines are consumed by the parser
-    145, 121,
-    // normalize not closed fence blocks
-    124, 127, 128, 139, 137, 126, 143,
-
-    // 'HTML blocks',
-    // spaces are consumed by the parser
-    // note: doesn't change semantics(i.e. same html render)
-    // extra spacing after paragraph doesn't change semantics
-    // but helps prevent joining with previous paragraph
-    182, 185, 180, 179, 177, 176, 172, 170, 169, 148,
-
-    174, 175,
-
-    // 'Block quotes'
-    // paragraphs
-    // blockquotes are lazy, semantics preserved
-    228, 229, 241, 233, 249, 243, 251,
-    // we always separate paragraphs
-    248,
-    // we always render spaces that follows blockquote even on empty lines
-    244,
-    // fences
-    // close fences explicitly
-    237,
-    // omit empty lines inside empty blockquote
-    240,
-    // leading spaces consumed by the parser
-    230,
-    // lists are not implemented
-    238,
-
-    // 'List items'
-    253, 254, 255, 256, 258, 259, 260, 262, 263, 268, 272, 273, 274, 275, 276, 277, 279, 280, 282,
-    286, 287, 288, 290, 291, 293, 299, 306, 307, 308, 309, 311, 313, 312, 314, 315, 316, 317, 319,
-    320, 324, 325, 326,
-]);
-
 const units = tests.filter(({section, number}) => {
-    const cond = semanticsTests.has(number);
-
-    // return cond;
-    if (cond) {
+    if (semantics.has(number)) {
         return false;
     }
 
-    if (!sectionsKeep.has(section)) {
+    if (!sections.has(section)) {
         return false;
     }
 
-    if (sectionsKeep.has(number)) {
+    if (sections.has(number)) {
         return false;
     }
 
     return true;
 });
 
-// omit first and last empty lines
-const filterOutEmptyFstLst = (line, i, ls) => (i && i + 1 !== ls.length) || line.trim().length;
-const normalizeMD = (str: string) => str.split('\n').filter(filterOutEmptyFstLst).join('\n');
-
+// todo: remove unnecessary logging
+// for now suppress it
 console.info = (a) => a;
 console.log = (a) => a;
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
     },
     moduleNameMapper: {
         '^src/(.*)': '<rootDir>/src/$1',
+        '^__tests__/(.*)': '<rootDir>/__tests__/$1',
     },
-    testPathIgnorePatterns: [`.*__fixtures__${path.sep}.*`],
+    testPathIgnorePatterns: [`.*__fixtures__${path.sep}.*`, `.*__helpers__${path.sep}.*`],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "src/*": ["src/*"]
+      "src/*": ["src/*"],
+      "__tests__/*": ["__tests__/*"]
     }
   }
 }


### PR DESCRIPTION
introduce snapshots tests for cases where we give up to achive markdown zero diff and settle for preserving semantics(i.e achieving same html render) Closes: #30 