### PR TITLE
plugin interface

### DIFF
--- a/__tests__/rules/markdown-semantics.ts
+++ b/__tests__/rules/markdown-semantics.ts
@@ -1,36 +1,19 @@
 import MarkdownIt from 'markdown-it';
-import {MarkdownRenderer, MarkdownRendererEnv, MarkdownRendererMode} from 'src/renderer';
+import {MarkdownRendererEnv} from 'src/renderer';
 import {tests} from 'commonmark-spec';
 
+import {mdRenderer} from 'src/plugin';
 import {semantics, CommonMarkSpecEntry} from './__fixtures__';
 import {normalizeMD} from '__tests__/__helpers__';
 
-const renderer = new MarkdownRenderer({mode: MarkdownRendererMode.Production});
-
 const md = new MarkdownIt('commonmark', {html: true});
 
-// todo: refactor into new interface
-// helpers
-// always evaluate to provided value <v>
-const always = (v: boolean) => () => v;
-// always return input value <a> as a result
-const id = (a: string) => a;
-
-// modify markdown-it parser behaviour
-// disable escape rule
-md.inline.ruler.at('escape', always(false));
-// disable entity rule
-md.inline.ruler.at('entity', always(false));
-// disable links normalization
-md.normalizeLink = id;
-
-// @ts-ignore
-md.renderer = renderer;
+md.use(mdRenderer);
 
 const units = tests.filter(({number}) => semantics.has(number));
 
 // todo: remove unnecessary logging
-// for now suppress it
+// for now suppress them
 console.log = (a) => a;
 console.info = (a) => a;
 

--- a/__tests__/rules/markdown-zero-diff.ts
+++ b/__tests__/rules/markdown-zero-diff.ts
@@ -1,31 +1,19 @@
 import MarkdownIt from 'markdown-it';
-import {MarkdownRenderer, MarkdownRendererEnv, MarkdownRendererMode} from 'src/renderer';
+import {MarkdownRendererEnv} from 'src/renderer';
 import {tests} from 'commonmark-spec';
 
+import {mdRenderer} from 'src/plugin';
 import {sections, semantics, CommonMarkSpecEntry} from './__fixtures__';
 import {normalizeMD} from '__tests__/__helpers__';
 
-const renderer = new MarkdownRenderer({mode: MarkdownRendererMode.Production});
-
 const md = new MarkdownIt('commonmark', {html: true});
 
-// todo: refactor into new interface
-// helpers
-// always evaluate to provided value <v>
-const always = (v: boolean) => () => v;
-// always return input value <a> as a result
-const id = (a: string) => a;
+md.use(mdRenderer);
 
-// modify markdown-it parser behaviour
-// disable escape rule
-md.inline.ruler.at('escape', always(false));
-// disable entity rule
-md.inline.ruler.at('entity', always(false));
-// disable links normalization
-md.normalizeLink = id;
-
-// @ts-ignore
-md.renderer = renderer;
+// todo: remove unnecessary logging
+// for now suppress them
+console.info = (a) => a;
+console.log = (a) => a;
 
 const units = tests.filter(({section, number}) => {
     if (semantics.has(number)) {
@@ -42,11 +30,6 @@ const units = tests.filter(({section, number}) => {
 
     return true;
 });
-
-// todo: remove unnecessary logging
-// for now suppress it
-console.info = (a) => a;
-console.log = (a) => a;
 
 describe('markdown zero diff', () => {
     units.forEach((entry: CommonMarkSpecEntry) => {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,0 +1,27 @@
+import type MarkdownIt from 'markdown-it';
+import {MarkdownRenderer, MarkdownRendererParams} from 'src/renderer';
+
+// import type {PluginWithOptions} from 'markdown-it';
+
+// helpers
+// always evaluate to provided value <v>
+const always = (v: boolean) => () => v;
+// always return input value <a> as a result
+const id = (a: string) => a;
+
+function mdRenderer(parser: MarkdownIt, parameters?: MarkdownRendererParams) {
+    // disable escape rule
+    parser.inline.ruler.at('escape', always(false));
+    // disable entity rule
+    parser.inline.ruler.at('entity', always(false));
+    // disable links normalization
+    parser.normalizeLink = id;
+
+    const renderer = new MarkdownRenderer(parameters);
+
+    // @ts-ignore
+    parser.renderer = renderer;
+}
+
+export {mdRenderer};
+export default {mdRenderer};


### PR DESCRIPTION
Markdown IT plugin interface

allows to configure MarkdownIt instance to render into markdown
just by adding the plugin

Closes: #34 